### PR TITLE
Update CMake file so it can build on docker debian buster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ target_include_directories(diff-pdf PRIVATE
     "${POPPLERGLIB_INCLUDE_DIRS}"
 )
 
-target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} stdc++fs)
+target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    target_link_libraries(diff-pdf stdc++fs)
+endif()
+
 target_link_directories(diff-pdf PRIVATE ${POPPLERGLIB_LIBRARY_DIRS})
 install(TARGETS diff-pdf RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,4 +14,4 @@ target_include_directories(diff-pdf PRIVATE
 
 target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} stdc++fs)
 target_link_directories(diff-pdf PRIVATE ${POPPLERGLIB_LIBRARY_DIRS})
-install(TARGETS diff-pdf RUNTIME DESTINATION /usr/local/bin)
+install(TARGETS diff-pdf RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,4 +14,4 @@ target_include_directories(diff-pdf PRIVATE
 
 target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} stdc++fs)
 target_link_directories(diff-pdf PRIVATE ${POPPLERGLIB_LIBRARY_DIRS})
-install(TARGETS diff-pdf RUNTIME DESTINATION bin)
+install(TARGETS diff-pdf RUNTIME DESTINATION /usr/local/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,6 @@ target_include_directories(diff-pdf PRIVATE
     "${POPPLERGLIB_INCLUDE_DIRS}"
 )
 
-target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES})
-target_link_directories(diff-pdf PRIVATE ${POPPLERGLIB_LIBRARY_DIRS} stdc++fs)
+target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} stdc++fs)
+target_link_directories(diff-pdf PRIVATE ${POPPLERGLIB_LIBRARY_DIRS})
 install(TARGETS diff-pdf RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ project(diff-pdf)
 cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CXX_STANDARD_REQUIRED true)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FindPkgConfig)
 
 pkg_search_module(POPPLERGLIB REQUIRED poppler-glib)
@@ -11,7 +11,7 @@ add_executable(diff-pdf diff-pdf.cpp)
 target_include_directories(diff-pdf PRIVATE
     "${POPPLERGLIB_INCLUDE_DIRS}"
 )
-target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES})
+target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} stdc++fs)
 target_link_directories(diff-pdf PRIVATE
     ${POPPLERGLIB_LIBRARY_DIRS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,16 +6,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FindPkgConfig)
 
 pkg_search_module(POPPLERGLIB REQUIRED poppler-glib)
-pkg_search_module(STDCFS REQUIRED stdc++fs)
-
 add_executable(diff-pdf diff-pdf.cpp)
+
 target_include_directories(diff-pdf PRIVATE
     "${POPPLERGLIB_INCLUDE_DIRS}"
-    "${STDCFS_INCLUDE_DIRS}"
 )
 
-target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} ${STDCFS_LIBRARIES})
-target_link_directories(diff-pdf PRIVATE
-    ${POPPLERGLIB_LIBRARY_DIRS} ${STDCFS_LIBRARY_DIRS}
-)
+target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES})
+target_link_directories(diff-pdf PRIVATE ${POPPLERGLIB_LIBRARY_DIRS} stdc++fs)
 install(TARGETS diff-pdf RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FindPkgConfig)
 
 pkg_search_module(POPPLERGLIB REQUIRED poppler-glib)
+pkg_search_module(STDCFS REQUIRED stdc++fs)
 
 add_executable(diff-pdf diff-pdf.cpp)
 target_include_directories(diff-pdf PRIVATE
     "${POPPLERGLIB_INCLUDE_DIRS}"
+    "${STDCFS_INCLUDE_DIRS}"
 )
-target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} stdc++fs)
+
+target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES} ${STDCFS_LIBRARIES})
 target_link_directories(diff-pdf PRIVATE
-    ${POPPLERGLIB_LIBRARY_DIRS}
+    ${POPPLERGLIB_LIBRARY_DIRS} ${STDCFS_LIBRARY_DIRS}
 )
 install(TARGETS diff-pdf RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,4 @@ target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES})
 target_link_directories(diff-pdf PRIVATE
     ${POPPLERGLIB_LIBRARY_DIRS}
 )
-install(TARGETS diff-pdf)
+install(TARGETS diff-pdf RUNTIME DESTINATION build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,4 @@ target_link_libraries(diff-pdf ${POPPLERGLIB_LIBRARIES})
 target_link_directories(diff-pdf PRIVATE
     ${POPPLERGLIB_LIBRARY_DIRS}
 )
-install(TARGETS diff-pdf RUNTIME DESTINATION build)
+install(TARGETS diff-pdf RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ project(diff-pdf)
 cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_CXX_STANDARD 17)
-
+set(CXX_STANDARD_REQUIRED true)
 include(FindPkgConfig)
 
 pkg_search_module(POPPLERGLIB REQUIRED poppler-glib)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ As for dependencies, diff-pdf requires the following libraries:
 - Cairo >= 1.4
 - Poppler >= 0.10
 
+#### Ubuntu (Dockerfile)
+```
+RUN apt-get install -y make automake cmake g++ libpoppler-glib-dev poppler-utils wxgtk3.0-dev git
+RUN mkdir diff-pdf
+WORKDIR /usr/src/app/diff-pdf
+RUN git clone --depth=1 https://github.com/ggilles/diff-pdf.git .
+RUN mkdir bin
+RUN cmake -v -S . -B bin -DCMAKE_BUILD_TYPE=Release
+RUN cmake --build bin
+RUN cmake --install bin
+RUN cp bin/diff-pdf /usr/local/bin
+```
+
 #### CentOS:
 
 ```
@@ -77,6 +90,7 @@ $ sudo yum install wxGTK wxGTK-devel poppler-glib poppler-glib-devel
 $ sudo apt-get install make automake g++
 $ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk3.0-dev
 ```
+
 
 #### macOS:
 Install Command Line Tools for Xcode:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## THIS IS A FORK OF `diff-pdf` THAT USES NO GRAPHICAL DISPLAY
+This makes it suitable for headless operations like running PDF comparison tests on a Docker container.
+
 *Note: this repository is provided **as-is** and the code is not being actively
 developed. If you wish to improve it, that's greatly appreciated: please make
 the changes and submit a pull request, I'll gladly merge it or help you out

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -373,13 +373,7 @@ int main(int argc, char *argv[]) {
   }
   g_free(uri2);
 
-  int retval = 0;
-
-  if (!pdf_file.empty()) {
-    gchar retval = doc_compare(doc1, doc2, pdf_file.c_str(), NULL) ? 0 : 1;
-  } else {
-    retval = doc_compare(doc1, doc2, NULL, NULL) ? 0 : 1;
-  }
+  int retval = doc_compare(doc1, doc2, pdf_file.empty() ? NULL : pdf_file.c_str(), NULL) ? 0 : 1;
 
   g_object_unref(doc1);
   g_object_unref(doc2);


### PR DESCRIPTION
I needed a version of diff-pdf without the wx dependencies to build it on a docker image where there's no window manager, so I found your repo which seemed promising.

I had some issues getting this to build on a docker image of debian buster because of missing libraries ([`stdc++fs` must be explicitly linked in gcc8](https://www.reddit.com/r/cpp_questions/comments/bf7dag/stdfilesystem_with_gcc_83_docker_image/)) and also because of missing `RUNTIME DESTINATION` but eventually I managed to get a working version to build using the changes in this PR.
